### PR TITLE
Allow nulls for write elements in MXSerializer

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/xml/pull/MXSerializer.java
+++ b/src/main/java/org/codehaus/plexus/util/xml/pull/MXSerializer.java
@@ -854,6 +854,9 @@ public class MXSerializer implements XmlSerializer {
     // --- utility methods
 
     protected void writeAttributeValue(String value, Writer out) throws IOException {
+        if (value == null) {
+            return;
+        }
         // .[apostrophe and <, & escaped],
         final char quot = attributeUseApostrophe ? '\'' : '"';
         final String quotEntity = attributeUseApostrophe ? "&apos;" : "&quot;";
@@ -908,6 +911,9 @@ public class MXSerializer implements XmlSerializer {
     }
 
     protected void writeElementContent(String text, Writer out) throws IOException {
+        if (text == null) {
+            return;
+        }
         // escape '<', '&', ']]>', <32 if necessary
         int pos = 0;
         for (int i = 0; i < text.length(); i++) {

--- a/src/test/java/org/codehaus/plexus/util/xml/pull/MXSerializerTest.java
+++ b/src/test/java/org/codehaus/plexus/util/xml/pull/MXSerializerTest.java
@@ -1,5 +1,6 @@
 package org.codehaus.plexus.util.xml.pull;
 
+import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Arrays;
@@ -54,5 +55,20 @@ class MXSerializerTest {
         out.append("<char>SHIFT IN: </char>");
         out.append("</root>");
         return out.toString();
+    }
+
+    /**
+     * Tests MJAVADOC-793.
+     */
+    @Test
+    public void testWriteNullValues() throws IOException {
+        // should be no-ops
+        new MXSerializer().writeElementContent(null, null);
+        new MXSerializer().writeAttributeValue(null, null);
+        final StringWriter stringWriter = new StringWriter();
+        new MXSerializer().writeElementContent(null, stringWriter);
+        assertEquals("", stringWriter.toString());
+        new MXSerializer().writeAttributeValue(null, stringWriter);
+        assertEquals("", stringWriter.toString());
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MJAVADOC-793

Allow nulls for write elements in `MXSerializer`.