### PR TITLE
Build against maven-xml 4.0.0-rc-6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-xml</artifactId>
-      <version>4.0.0-rc-5</version>
+      <version>4.0.0-rc-6</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.sisu</groupId>


### PR DESCRIPTION
4.0.0-rc-6 is released; this moves the `maven-xml` dependency to it.

Verified: green on the fork before opening.
