### PR TITLE
Rewrite README with usage, status and version guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,56 @@
-Plexus-Xml
-==========
+# Plexus XML
 
-[![Build Status](https://github.com/codehaus-plexus/plexus-xml/actions/workflows/maven.yml/badge.svg)](https://github.com/codehaus-plexus/plexus-xml/actions)
-[![Maven Central](https://img.shields.io/maven-central/v/org.codehaus.plexus/plexus-xml.svg?label=Maven%20Central&versionPrefix=3.)](https://search.maven.org/artifact/org.codehaus.plexus/plexus-xml)
-[![Maven Central](https://img.shields.io/maven-central/v/org.codehaus.plexus/plexus-xml.svg?label=Maven%20Central)](https://search.maven.org/artifact/org.codehaus.plexus/plexus-xml)
+[![Maven Central](https://img.shields.io/maven-central/v/org.codehaus.plexus/plexus-xml.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/org.codehaus.plexus/plexus-xml)
+[![GitHub CI](https://github.com/codehaus-plexus/plexus-xml/actions/workflows/maven.yml/badge.svg)](https://github.com/codehaus-plexus/plexus-xml/actions)
 [![Reproducible Builds](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jvm-repo-rebuild/reproducible-central/master/content/org/codehaus/plexus/plexus-xml/badge.json)](https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/codehaus/plexus/plexus-xml/README.md)
 
-This library consists of XML classes (`org.codehaus.plexus.util.xml` and `org.codehaus.plexus.util.xml.pull`) that:
+The XML classes — `Xpp3Dom`, `Xpp3DomBuilder`, `Xpp3DomWriter` and the XML pull parser — that used to live in
+`plexus-utils`, in the packages `org.codehaus.plexus.util.xml` and `org.codehaus.plexus.util.xml.pull`.
 
-1. have been extracted from [`plexus-utils`](https://github.com/codehaus-plexus/plexus-utils/) 4:\
-   this step is released as `plexus-xml` 3, maintained in [3.x branch](tree/3.x)\
-   [![Maven Central](https://img.shields.io/maven-central/v/org.codehaus.plexus/plexus-xml.svg?label=Maven%20Central&versionPrefix=3.)](https://search.maven.org/artifact/org.codehaus.plexus/plexus-xml),
+## Status
 
-2. then updated to use Maven 4-specific [`maven-xml-api`](https://github.com/apache/maven/tree/maven-4.0.0-rc-2/api/maven-api-xml)/[`maven-xml`](https://github.com/apache/maven/tree/maven-4.0.0-rc-2/maven-xml):\
-   this is the `master` branch from which `plexus-xml` 4 is released\
-   Version 4.x requires Java 17 (like Maven 4)
-   [![Maven Central](https://img.shields.io/maven-central/v/org.codehaus.plexus/plexus-xml.svg?label=Maven%20Central)](https://search.maven.org/artifact/org.codehaus.plexus/plexus-xml)
+Maintained. **Two lines exist and they are not interchangeable** — pick deliberately:
 
-For publishing [the site](https://codehaus-plexus.github.io/plexus-xml/) do the following:
+| Line  |  Requires   |     Works under     |                         Use when                          |
+|-------|-------------|---------------------|-----------------------------------------------------------|
+| `3.x` | Java 8      | Maven 3 and Maven 4 | You split from `plexus-utils` 4 and want the same classes |
+| `4.x` | **Java 17** | **Maven 4 only**    | You are building for Maven 4                              |
 
+`3.x` is the straight extraction from `plexus-utils` 4 — same classes, same packages — and is maintained on
+the [`3.x` branch](https://github.com/codehaus-plexus/plexus-xml/tree/3.x).
+
+`4.x` is rebuilt on Maven 4's [`maven-xml-api`](https://maven.apache.org/ref/4-LATEST/api/maven-api-xml/)
+and works only under Maven 4.
+
+If you are here because upgrading `plexus-utils` 3 → 4 gave you a `NoClassDefFoundError` on `Xpp3Dom`,
+you want **`3.x`**.
+
+## Using it
+
+```xml
+<dependency>
+  <groupId>org.codehaus.plexus</groupId>
+  <artifactId>plexus-xml</artifactId>
+  <version>4.1.1</version>
+</dependency>
 ```
-mvn -Preporting verify site site:stage scm-publish:publish-scm
-```
 
+Check the badge above for the current version, and read the table before taking it.
+
+## Requirements
+
+Java 17 for `4.x`. Java 8 for `3.x`.
+
+## Documentation
+
+- [Project site](https://codehaus-plexus.github.io/plexus-xml/)
+- [Javadoc](https://javadoc.io/doc/org.codehaus.plexus/plexus-xml)
+- [Release notes](https://github.com/codehaus-plexus/plexus-xml/releases)
+
+## Contributing
+
+See [CONTRIBUTING.md](https://github.com/codehaus-plexus/.github/blob/master/CONTRIBUTING.md). In short:
+`mvn verify` builds, and run `mvn spotless:apply` before pushing or CI will fail on formatting.
+
+Please report security vulnerabilities privately — see
+[SECURITY.md](https://github.com/codehaus-plexus/.github/blob/master/SECURITY.md), not a public issue.


### PR DESCRIPTION
Part of codehaus-plexus/.github#58. Same skeleton as the merged pilots (codehaus-plexus/plexus-archiver#438, codehaus-plexus/plexus-i18n#37, codehaus-plexus/plexus-utils#332).

The old README explained *how* the split happened — the history of the extraction from `plexus-utils` — but never answered the question people actually arrive with: **which line do I take?**

That matters more here than in most repos, because the two are not interchangeable:

| Line | Requires | Works under |
|---|---|---|
| `3.x` | Java 8 | Maven 3 and Maven 4 |
| `4.x` | **Java 17** | **Maven 4 only** |

Taking `4.x` when you needed `3.x` fails at runtime under Maven 3, and nothing in the README said so. It now leads with that table, and adds the sentence I would give someone who turned up confused:

> If you are here because upgrading `plexus-utils` 3 → 4 gave you a `NoClassDefFoundError` on `Xpp3Dom`, you want **`3.x`**.

Also adds the dependency snippet and the Java baseline — this was one of only two READMEs in the org that mentioned a Java version at all, and it did so in prose rather than anywhere findable.

Ran `mvn spotless:apply`.